### PR TITLE
Update CodeEditorField.ss and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ Creates an Ace Code Editor (https://ace.c9.io/)
 ```php
 $fields->push(CodeEditorField::create('MyCode', 'Enter Source Code Here'));
 ```
+
+## Setting the Programming Language Mode
+
+```php
+$fields->push($myCodeEditorField = CodeEditorField::create('MyCode', 'Enter Source Code Here'));
+
+// set mode to html
+$myCodeEditorField->setMode('ace/mode/html');
+// or javascript
+$myCodeEditorField->setMode('ace/mode/javascript');
+```
+see [resources/thirdparty/ace](resources/thirdparty/ace) for available modes (mode-{language}.js)

--- a/templates/SwiftDevLabs/CodeEditorField/Forms/CodeEditorField.ss
+++ b/templates/SwiftDevLabs/CodeEditorField/Forms/CodeEditorField.ss
@@ -1,2 +1,2 @@
 <div id="{$ID}_CodeEditorField" class="codeeditorfield" style="min-height: {$Height}px;" data-field="{$Name}">$Value</div>
-<textarea $AttributesHTML style="display: none;">{$Value.RAW}</textarea>
+<textarea $AttributesHTML style="display: none;">{$Value}</textarea>

--- a/templates/SwiftDevLabs/CodeEditorField/Forms/CodeEditorField.ss
+++ b/templates/SwiftDevLabs/CodeEditorField/Forms/CodeEditorField.ss
@@ -1,2 +1,2 @@
 <div id="{$ID}_CodeEditorField" class="codeeditorfield" style="min-height: {$Height}px;" data-field="{$Name}">$Value</div>
-<textarea $AttributesHTML style="display: none;">{$Value}</textarea>
+<textarea $AttributesHTML style="display: none;">{$ValueEntities.RAW}</textarea>


### PR DESCRIPTION
prevent '<script>'-tags from breaking the cms (e.g. SiteConfig/Settings not loading anymore)